### PR TITLE
Pass germline non-matched tumor-normal data

### DIFF
--- a/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/GenerateMaskedRow.java
+++ b/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/GenerateMaskedRow.java
@@ -50,7 +50,7 @@ public class GenerateMaskedRow implements FlatMapFunction<ObjectNode, ObjectNode
     // https://wiki.oicr.on.ca/display/DCCSOFT/Data+Normalizer+Component?focusedCommentId=53182773#comment-53182773)
 
     val rows = Lists.<ObjectNode> newArrayList();
-    rows.add(row);
+//    rows.add(row);
 
     if (getMarkingState(row) == CONTROLLED) {
       val referenceGenomeAllele = row.get(SUBMISSION_OBSERVATION_REFERENCE_GENOME_ALLELE).textValue();

--- a/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/MarkSensitiveRow.java
+++ b/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/MarkSensitiveRow.java
@@ -43,6 +43,8 @@ import com.google.common.base.Splitter;
 public class MarkSensitiveRow implements Function<ObjectNode, ObjectNode> {
 
   private static final Splitter ALLELES_SPLITTER = Splitter.on("/");
+  // Pass Non-matched data
+  private static final String NONMATCHED_VALUE = null;
 
   @Override
   public ObjectNode call(ObjectNode row) throws Exception {
@@ -55,11 +57,7 @@ public class MarkSensitiveRow implements Function<ObjectNode, ObjectNode> {
     // Mark if applicable
     final Marking masking;
 
-    // Pass Non-matched data
-    private final static String NONMATCHED_VALUE = null;
-
-    if (controlGenotype == NONMATCHED_VALUE || tumourGenotype == NONMATCHED_VALUE 
-	|| mutatedFromAllele == NONMATCHED_VALUE) {
+    if (controlGenotype == NONMATCHED_VALUE || tumourGenotype == NONMATCHED_VALUE || mutatedFromAllele == NONMATCHED_VALUE) {
 
       log.debug("Marking row without control data: '{}'", row);
       masking = CONTROLLED;

--- a/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/MarkSensitiveRow.java
+++ b/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/MarkSensitiveRow.java
@@ -54,7 +54,12 @@ public class MarkSensitiveRow implements Function<ObjectNode, ObjectNode> {
 
     // Mark if applicable
     final Marking masking;
-    if (controlGenotype == null || tumourGenotype == null || mutatedFromAllele == null) {
+
+    // Pass Non-matched data
+    private final static String NONMATCHED_VALUE = null;
+
+    if (controlGenotype == NONMATCHED_VALUE || tumourGenotype == NONMATCHED_VALUE 
+	|| mutatedFromAllele == NONMATCHED_VALUE) {
 
       log.debug("Marking row without control data: '{}'", row);
       masking = CONTROLLED;

--- a/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/MarkSensitiveRow.java
+++ b/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/MarkSensitiveRow.java
@@ -22,6 +22,7 @@ import static com.google.common.collect.Sets.newLinkedHashSet;
 import static org.icgc.dcc.common.core.model.FieldNames.NormalizerFieldNames.NORMALIZER_MARKING;
 import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_CONTROL_GENOTYPE;
 import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_MUTATED_TO_ALLELE;
+import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_MUTATED_FROM_ALLELE;
 import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_REFERENCE_GENOME_ALLELE;
 import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_TUMOUR_GENOTYPE;
 import static org.icgc.dcc.common.core.model.Marking.CONTROLLED;
@@ -49,10 +50,16 @@ public class MarkSensitiveRow implements Function<ObjectNode, ObjectNode> {
     val controlGenotype = row.get(SUBMISSION_OBSERVATION_CONTROL_GENOTYPE).textValue();
     val tumourGenotype = row.get(SUBMISSION_OBSERVATION_TUMOUR_GENOTYPE).textValue();
     val mutatedToAllele = row.get(SUBMISSION_OBSERVATION_MUTATED_TO_ALLELE).textValue();
+    val mutatedFromAllele = row.get(SUBMISSION_OBSERVATION_MUTATED_FROM_ALLELE).textValue();
 
     // Mark if applicable
     final Marking masking;
-    if (!matchesAllControlAlleles(referenceGenomeAllele, controlGenotype)
+    if (controlGenotype == null || tumourGenotype == null || mutatedFromAllele == null) {
+
+      log.debug("Marking row without control data: '{}'", row);
+      masking = CONTROLLED;
+
+    } else if (!matchesAllControlAlleles(referenceGenomeAllele, controlGenotype)
         || !matchesAllTumourAllelesButTo(referenceGenomeAllele, tumourGenotype, mutatedToAllele)) {
 
       log.debug("Marking sensitive row: '{}'", row); // Should be rare enough

--- a/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/RebuildMutation.java
+++ b/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/RebuildMutation.java
@@ -21,13 +21,16 @@ import static com.google.common.base.Joiner.on;
 import static org.icgc.dcc.common.core.model.FieldNames.NormalizerFieldNames.NORMALIZER_MUTATION;
 import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_MUTATED_FROM_ALLELE;
 import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_MUTATED_TO_ALLELE;
+
 import lombok.val;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.spark.api.java.function.Function;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Joiner;
 
+@Slf4j
 public class RebuildMutation implements Function<ObjectNode, ObjectNode> {
 
   /**

--- a/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/RebuildMutation.java
+++ b/dcc-release-job/dcc-release-job-mask/src/main/java/org/icgc/dcc/release/job/mask/function/RebuildMutation.java
@@ -21,16 +21,13 @@ import static com.google.common.base.Joiner.on;
 import static org.icgc.dcc.common.core.model.FieldNames.NormalizerFieldNames.NORMALIZER_MUTATION;
 import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_MUTATED_FROM_ALLELE;
 import static org.icgc.dcc.common.core.model.FieldNames.SubmissionFieldNames.SUBMISSION_OBSERVATION_MUTATED_TO_ALLELE;
-
 import lombok.val;
-import lombok.extern.slf4j.Slf4j;
 
 import org.apache.spark.api.java.function.Function;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Joiner;
 
-@Slf4j
 public class RebuildMutation implements Function<ObjectNode, ObjectNode> {
 
   /**


### PR DESCRIPTION
This PR edits the MASK stage of the release pipeline, so that the pipeline is capable of reading data that is not matched tumor-normal. 

It does this by treating every sample without control sample genotype data as if it was masked. 